### PR TITLE
Remove CI for MW 1.35

### DIFF
--- a/.env-39
+++ b/.env-39
@@ -1,5 +1,0 @@
-# docker images
-MW_VERSION?=1.39
-PHP_VERSION?=8.1
-DB_TYPE?=mysql
-DB_IMAGE?="mysql:8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,37 +17,43 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.35'
-            php_version: 7.4
-            database_type: mysql
-            database_image: "mysql:5.7"
-            coverage: false
-            experimental: false
           - mediawiki_version: '1.39'
+            smw_version: dev-master
             php_version: 8.1
             database_type: mysql
-            database_image: "mysql:8"
+            database_image: "mariadb:10"
             coverage: false
+            experimental: false
+          - mediawiki_version: '1.40'
+            smw_version: dev-master
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: true
             experimental: false
           - mediawiki_version: '1.41'
+            smw_version: dev-master
             php_version: 8.1
             database_type: mysql
-            database_image: "mysql:8"
+            database_image: "mariadb:11.2"
             coverage: false
             experimental: false
           - mediawiki_version: '1.42'
-            php_version: 8.2
+            smw_version: dev-master
+            php_version: 8.1
             database_type: mysql
-            database_image: "mysql:8"
+            database_image: "mariadb:11.2"
             coverage: false
             experimental: false
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}
+      SMW_VERSION: ${{ matrix.smw_version }}
       PHP_VERSION: ${{ matrix.php_version }}
       DB_TYPE: ${{ matrix.database_type }}
       DB_IMAGE: ${{ matrix.database_image }}
 
+      
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,7 +62,7 @@ jobs:
                    
       - name: Update submodules
         run: git submodule update --init --remote
-  
+
       - name: Run tests
         run: make ci
         if: matrix.coverage == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,28 +18,24 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.39'
-            smw_version: dev-master
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:10"
             coverage: false
             experimental: false
           - mediawiki_version: '1.40'
-            smw_version: dev-master
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: true
             experimental: false
           - mediawiki_version: '1.41'
-            smw_version: dev-master
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: false
             experimental: false
           - mediawiki_version: '1.42'
-            smw_version: dev-master
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
@@ -48,7 +44,6 @@ jobs:
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}
-      SMW_VERSION: ${{ matrix.smw_version }}
       PHP_VERSION: ${{ matrix.php_version }}
       DB_TYPE: ${{ matrix.database_type }}
       DB_IMAGE: ${{ matrix.database_image }}

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ DB_TYPE?=mysql
 DB_IMAGE?="mariadb:10"
 
 # extensions
-SMW_VERSION?=dev-master
 
 # composer
 # Enables "composer update" inside of extension

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,20 @@ export
 # setup for docker-compose-ci build directory
 # delete "build" directory to update docker-compose-ci
 
-ifeq (,$(wildcard ./build/Makefile))
+ifeq (,$(wildcard ./build/))
     $(shell git submodule update --init --remote)
 endif
 
 EXTENSION=KnowledgeGraph
 
 # docker images
-MW_VERSION?=1.35
-PHP_VERSION?=7.4
-DB_TYPE?=sqlite
-DB_IMAGE?=""
+MW_VERSION?=1.39
+PHP_VERSION?=8.1
+DB_TYPE?=mysql
+DB_IMAGE?="mariadb:10"
 
 # extensions
+SMW_VERSION?=dev-master
 
 # composer
 # Enables "composer update" inside of extension

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "/var/www/html/extensions/KnowledgeGraph/::"

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,22 @@
 {
 	"name": "mediawiki/knowledge-graph",
   	"type": "mediawiki-extension",
+	"require": {
+		"composer/installers": ">=1.0.1"
+	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "43.0.0",
 		"mediawiki/mediawiki-phan-config": "0.14.0",
 		"mediawiki/minus-x": "1.1.3",
 		"php-parallel-lint/php-console-highlighter": "1.0.0",
 		"php-parallel-lint/php-parallel-lint": "1.4.0"
+	},
+	"config": {
+		"process-timeout": 0,
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	},
 	"scripts": {
 		"test": [

--- a/extension.json
+++ b/extension.json
@@ -116,5 +116,6 @@
 			"value": false
 		}
 	},
+	"load_composer_autoloader": true,
 	"manifest_version": 2
 }

--- a/extension.json
+++ b/extension.json
@@ -116,6 +116,5 @@
 			"value": false
 		}
 	},
-	"load_composer_autoloader": true,
 	"manifest_version": 2
 }

--- a/extension.json
+++ b/extension.json
@@ -116,5 +116,5 @@
 			"value": false
 		}
 	},
-	"manifest_version": 2,
+	"manifest_version": 2
 }

--- a/extension.json
+++ b/extension.json
@@ -1,29 +1,28 @@
 {
-    "manifest_version": 2,
-    "name": "KnowledgeGraph",
-    "version": "1.0",
-    "author": "Thomas-topway-it for [https://knowledge.wiki KM-A]",
-    "url": "https://github.com/SemanticMediaWiki/KnowledgeGraph",
-    "descriptionmsg": "knowledge-graph-desc",
-    "namemsg": "knowledge-graph-name",
-    "type":"semantic",
-    "requires":{
-        "MediaWiki":">= 1.31"
-    },
-    "MessagesDirs": {
-        "KnowledgeGraph":[
-            "i18n"
-        ]
-    },
+	"name": "KnowledgeGraph",
+	"version": "2.0-beta",
+	"author": "Thomas-topway-it for [https://knowledge.wiki KM-A]",
+	"url": "https://github.com/SemanticMediaWiki/KnowledgeGraph",
+	"descriptionmsg": "knowledge-graph-desc",
+	"namemsg": "knowledge-graph-name",
+	"type":"semantic",
+	"requires":{
+		"MediaWiki": ">= 1.39"
+	},
+	"MessagesDirs": {
+		"KnowledgeGraph":[
+			"i18n"
+		]
+	},
 	"ExtensionMessagesFiles": {
 		"KnowledgeGraphMagic": "KnowledgeGraph.i18n.magic.php"
 	},
-    "AutoloadClasses": {
-        "KnowledgeGraph":"includes/KnowledgeGraph.php",
-        "SpecialKnowledgeGraphDesigner":"includes/specials/SpecialKnowledgeGraphDesigner.php",
-        "KnowledgeGraphApiLoadNodes": "includes/api/KnowledgeGraphApiLoadNodes.php",
-        "KnowledgeGraphApiLoadProperties": "includes/api/KnowledgeGraphApiLoadProperties.php",
-        "KnowledgeGraphApiLoadCategories": "includes/api/KnowledgeGraphApiLoadCategories.php"
+	"AutoloadClasses": {
+		"KnowledgeGraph":"includes/KnowledgeGraph.php",
+		"SpecialKnowledgeGraphDesigner":"includes/specials/SpecialKnowledgeGraphDesigner.php",
+		"KnowledgeGraphApiLoadNodes": "includes/api/KnowledgeGraphApiLoadNodes.php",
+		"KnowledgeGraphApiLoadProperties": "includes/api/KnowledgeGraphApiLoadProperties.php",
+		"KnowledgeGraphApiLoadCategories": "includes/api/KnowledgeGraphApiLoadCategories.php"
 	},
 	"APIModules": {
 		"knowledgegraph-load-nodes": "KnowledgeGraphApiLoadNodes",
@@ -33,25 +32,25 @@
 	"SpecialPages": {
 		"KnowledgeGraphDesigner": "SpecialKnowledgeGraphDesigner"
 	},
-    "Hooks":{
+	"Hooks":{
 		"LoadExtensionSchemaUpdates": "KnowledgeGraph::onLoadExtensionSchemaUpdates",
 		"BeforePageDisplay":"KnowledgeGraph::onBeforePageDisplay",
 		"ParserFirstCallInit": "KnowledgeGraph::onParserFirstCallInit",
 		"OutputPageParserOutput": "KnowledgeGraph::onOutputPageParserOutput",
 		"SidebarBeforeOutput": "KnowledgeGraph::onSidebarBeforeOutput"
-    },
+	},
 	"ResourceModules":{
-        "ext.KnowledgeGraph":{
-            "localBasePath":"resources",
-            "remoteExtPath":"KnowledgeGraph/resources",
-            "styles":[
-                "KnowledgeGraph.css"
-            ],
-            "scripts":[
-                "visNetwork/vis-network.min.js",
-                "KnowledgeGraph.js"
-            ],
-            "dependencies": [
+		"ext.KnowledgeGraph":{
+			"localBasePath":"resources",
+			"remoteExtPath":"KnowledgeGraph/resources",
+			"styles":[
+				"KnowledgeGraph.css"
+			],
+			"scripts":[
+				"visNetwork/vis-network.min.js",
+				"KnowledgeGraph.js"
+			],
+			"dependencies": [
 				"mediawiki.util",
 				"mediawiki.base",
 				"mediawiki.cookie",
@@ -67,10 +66,10 @@
 				"oojs-ui.styles.icons-editing-core",
 				"oojs-ui.styles.icons-interactions",
 				"oojs-ui.styles.icons-accessibility"
-            ],
-            "position":"top",
-            "messages": [
-            	"knowledgegraph-toolbar-info",
+			],
+			"position":"top",
+			"messages": [
+				"knowledgegraph-toolbar-info",
 				"knowledgegraph-toolbar-help",
 				"knowledgegraph-graph-options-message",
 				"knowledgegraph-menu-open-article",
@@ -104,8 +103,8 @@
 				"knowledgegraph-credits",
 				"knowledgegraph-credits-list"
 			]
-        }
-    },
+		}
+	},
 	"config": {
 		"KnowledgeGraphDisableCredits": {
 			"value": false
@@ -116,5 +115,6 @@
 		"KnowledgeGraphShowSidebarLink": {
 			"value": false
 		}
-	}
+	},
+	"manifest_version": 2,
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,15 @@
-<phpunit colors="true">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         cacheTokens="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         verbose="true">
     <testsuites>
         <testsuite name="Unit">
             <directory>tests/phpunit/Unit</directory>


### PR DESCRIPTION
* Adds ci for MW 1.40 and make it enable code coverage.
* Bump up minimum MW version to MW 1.39. README already specifies that MW 1.39+ should be used.
* Bumps version to 2.0-beta.