### PR TITLE
Fix for MW 1.43

### DIFF
--- a/tests/phpunit/Unit/api/KnowledgeGraphApiLoadCategoriesTest.php
+++ b/tests/phpunit/Unit/api/KnowledgeGraphApiLoadCategoriesTest.php
@@ -8,7 +8,7 @@ class KnowledgeGraphApiLoadCategoriesTest extends TestCase {
 	 * @covers KnowledgeGraphApiLoadCategories::getExamplesMessages
 	 */
 	public function testGetExamples() {
-		$instance = new KnowledgeGraphApiLoadCategories( new ApiMain(), null );
+		$instance = new KnowledgeGraphApiLoadCategories( new ApiMain(), '' );
 		$messages = $instance->getExamplesMessages();
 		$this->assertCount( 1, $messages );
 	}

--- a/tests/phpunit/Unit/api/KnowledgeGraphApiLoadNodesTest.php
+++ b/tests/phpunit/Unit/api/KnowledgeGraphApiLoadNodesTest.php
@@ -8,7 +8,7 @@ class KnowledgeGraphApiLoadNodesTest extends TestCase {
 	 * @covers KnowledgeGraphApiLoadNodes::getExamplesMessages
 	 */
 	public function testGetExamples() {
-		$instance = new KnowledgeGraphApiLoadNodes( new ApiMain(), null );
+		$instance = new KnowledgeGraphApiLoadNodes( new ApiMain(), '' );
 		$messages = $instance->getExamplesMessages();
 		$this->assertCount( 1, $messages );
 	}

--- a/tests/phpunit/Unit/api/KnowledgeGraphApiLoadPropertiesTest.php
+++ b/tests/phpunit/Unit/api/KnowledgeGraphApiLoadPropertiesTest.php
@@ -8,7 +8,7 @@ class KnowledgeGraphApiLoadPropertiesTest extends TestCase {
 	 * @covers KnowledgeGraphApiLoadProperties::getExamplesMessages
 	 */
 	public function testGetExamples() {
-		$instance = new KnowledgeGraphApiLoadProperties( new ApiMain(), null );
+		$instance = new KnowledgeGraphApiLoadProperties( new ApiMain(), '' );
 		$messages = $instance->getExamplesMessages();
 		$this->assertCount( 1, $messages );
 	}


### PR DESCRIPTION
>    │ TypeError: MediaWiki\Api\ApiBase::__construct(): Argument #2 ($moduleName) must be of type string, null given, called in /var/www/html/extensions/KnowledgeGraph/tests/phpunit/Unit/api/KnowledgeGraphApiLoadCategoriesTest.php on line 11


Changed in [0].

[0] https://github.com/wikimedia/mediawiki/commit/1145328459f74043727456253894d9168473cb8f#diff-dfdd0dae9f9ed19e37ff6da63da042be73458adf8bda6151258aca1cd9a5ac86